### PR TITLE
GitHub release from tags

### DIFF
--- a/.github/workflows/gradle-build-pr.yml
+++ b/.github/workflows/gradle-build-pr.yml
@@ -9,6 +9,7 @@ jobs:
       with:
         java-version: 8
     - uses: eskatos/gradle-command-action@v1
+      name: Build
       with:
         gradle-version: current
         arguments: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         gradle-version: current
         arguments: |
-          publish -Psigning.secretKeyRingFile=secret.gpg \
+          upload -Psigning.secretKeyRingFile=secret.gpg \
           -Psigning.keyId=${{secrets.SIGNING_KEYID}} \
           -Psigning.password=${{secrets.SIGNING_PASSWORD}} \
           -PnexusUsername=${{secrets.NEXUS_USERNAME}} \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,17 @@
+name: Release
+on:
+  push:
+#    branches:
+#      - master
+jobs:
+  gradle:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions/setup-java@master
+      with:
+        java-version: 8
+    - uses: eskatos/gradle-command-action@v1
+      with:
+        gradle-version: current
+        arguments: build upload

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,7 @@
 name: Release
-on:
-  push:
-#    branches:
-#      - master
+on: [push]
 jobs:
-  gradle:
+  release:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
@@ -12,6 +9,22 @@ jobs:
       with:
         java-version: 8
     - uses: eskatos/gradle-command-action@v1
+      name: Build
       with:
         gradle-version: current
-        arguments: build upload
+        arguments: build
+    - name: Prepare to publish
+      run: |
+        echo '${{secrets.GPG_KEY_CONTENTS}}' | base64 -d > publish_key.gpg
+        gpg --quiet --batch --yes --decrypt --passphrase="${{secrets.SECRET_PASSPHRASE}}" \
+        --output secret.gpg publish_key.gpg
+    - uses: eskatos/gradle-command-action@v1
+      name: Publish artifact
+      with:
+        gradle-version: current
+        arguments: |
+          publish -Psigning.secretKeyRingFile=secret.gpg \
+          -Psigning.keyId=${{secrets.SIGNING_KEYID}} \
+          -Psigning.password=${{secrets.SIGNING_PASSWORD}} \
+          -PnexusUsername=${{secrets.NEXUS_USERNAME}} \
+          -PnexusPassword=${{secrets.NEXUS_PASSWORD}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
-on: [push]
+on:
+  push:
+    tags:
+      - 'v*'
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -18,6 +21,7 @@ jobs:
         echo '${{secrets.GPG_KEY_CONTENTS}}' | base64 -d > publish_key.gpg
         gpg --quiet --batch --yes --decrypt --passphrase="${{secrets.SECRET_PASSPHRASE}}" \
         --output secret.gpg publish_key.gpg
+        echo "::set-env name=RELEASE_VERSION::${GITHUB_REF:11}"
     - uses: eskatos/gradle-command-action@v1
       name: Publish artifact
       with:
@@ -28,3 +32,4 @@ jobs:
           -Psigning.password=${{secrets.SIGNING_PASSWORD}}
           -PnexusUsername=${{secrets.NEXUS_USERNAME}}
           -PnexusPassword=${{secrets.NEXUS_PASSWORD}}
+          -Pversion=${{RELEASE_VERSION}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,9 @@ jobs:
       name: Publish artifact
       with:
         gradle-version: current
-        arguments: |
-          upload -Psigning.secretKeyRingFile=secret.gpg \
-          -Psigning.keyId=${{secrets.SIGNING_KEYID}} \
-          -Psigning.password=${{secrets.SIGNING_PASSWORD}} \
-          -PnexusUsername=${{secrets.NEXUS_USERNAME}} \
+        arguments: >
+          upload -Psigning.secretKeyRingFile=secret.gpg
+          -Psigning.keyId=${{secrets.SIGNING_KEYID}}
+          -Psigning.password=${{secrets.SIGNING_PASSWORD}}
+          -PnexusUsername=${{secrets.NEXUS_USERNAME}}
           -PnexusPassword=${{secrets.NEXUS_PASSWORD}}


### PR DESCRIPTION
After tags like v1.0.0 will be pushed, it will trigger to publish artifact on oss.sonatype.org https://oss.sonatype.org/#nexus-search;quick~gmp-tools as snapshot with version 1.0.0

Later need to add workflow which will trigger on master branch increase of version and adding tags with needed version.

Also need to publish release from snapshot in oss.sonatype.org after the publishing it there.