### PR TITLE
Move release-on-push-action to action of creator

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - id: release
-        uses: dmitriyStoyanov/release-on-push-action@master
+        uses: rymndhng/release-on-push-action@master
         with:
           bump_version_scheme: patch
       - uses: actions/checkout@master


### PR DESCRIPTION
Move release-on-push-action to rymndhng/release-on-push-action@master from forked repo after https://github.com/rymndhng/release-on-push-action/pull/37 has been merged