### PR TITLE
Set default editor v2 for confluence

### DIFF
--- a/src/main/groovy/com/epam/esp/confluence/dto/NewConfPageDto.groovy
+++ b/src/main/groovy/com/epam/esp/confluence/dto/NewConfPageDto.groovy
@@ -30,10 +30,14 @@ class NewConfPageDto {
         def ancestors = new ArrayList<ConfPageAncestors>()
         ancestors.add(new ConfPageAncestors(ancestor))
         this.ancestors = ancestors
-        this.metadata = ['editor'                      : ['key': 'editor', 'value': 'v2'],
-                         'content-appearance-draft'    : ['key': 'content-appearance-draft', 'value': 'full-width'],
-                         'content-appearance-published': ['key': 'content-appearance-published', 'value': 'full-width']
-        ]
+        this.metadata =
+                ['properties':
+                         [
+                                 'editor'                      : ['value': 'v2'],
+                                 'content-appearance-draft'    : ['key': 'content-appearance-draft', 'value': 'full-width'],
+                                 'content-appearance-published': ['key': 'content-appearance-published', 'value': 'full-width']
+                         ]
+                ]
     }
 
     NewConfPageDto(String space, Long ancestor, String title, String body, Map<String, Object> meta) {

--- a/src/main/groovy/com/epam/esp/confluence/dto/NewConfPageDto.groovy
+++ b/src/main/groovy/com/epam/esp/confluence/dto/NewConfPageDto.groovy
@@ -30,14 +30,11 @@ class NewConfPageDto {
         def ancestors = new ArrayList<ConfPageAncestors>()
         ancestors.add(new ConfPageAncestors(ancestor))
         this.ancestors = ancestors
-        this.metadata =
-                ['properties':
-                         [
-                                 'editor'                      : ['value': 'v2'],
-                                 'content-appearance-draft'    : ['key': 'content-appearance-draft', 'value': 'full-width'],
-                                 'content-appearance-published': ['key': 'content-appearance-published', 'value': 'full-width']
-                         ]
-                ]
+        this.metadata = [
+                'editor'                      : ['value': 'v2'],
+                'content-appearance-draft'    : ['key': 'content-appearance-draft', 'value': 'full-width'],
+                'content-appearance-published': ['key': 'content-appearance-published', 'value': 'full-width']
+        ]
     }
 
     NewConfPageDto(String space, Long ancestor, String title, String body, Map<String, Object> meta) {


### PR DESCRIPTION
According to GitHub cloud documentation we should use the following structure for using of the Confluence editor v2:
```
"metadata": {
    "properties": {
      "editor" : {
         "value" : "v2"
       }
     }
   }
```